### PR TITLE
restore Makefile_all; fixes #11

### DIFF
--- a/Makefile_all
+++ b/Makefile_all
@@ -17,7 +17,7 @@ $(RESDIR)/%.png: $(TMPDIR)/%.dat source/plotcount.py
 	python source/plotcount.py $<  $@
 
 $(RESDIR)/results.txt: $(DATA) source/zipf_test.py
-	python source/zipf_test.py $^ > $@
+	python source/zipf_test.py $(DATA) > $@
 
 clean:
 	@$(RM) $(TMPDIR)/*


### PR DESCRIPTION
the reason was that source/zipf_test.py was also processing itself