### PR TITLE
Andestro/snakemake dependency fix #2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 numpy==1.16.4
 matplotlib==3.1.0
-git+https://github.com/pytries/datrie.git@3e22a27ca0104fe3c62b3251c0b75c281f089e43
-snakemake==5.5.0
+snakemake-minimal==5.7.1
 
 # to check python code style
 pycodestyle

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
+snakemake==3.13.3
 numpy==1.16.4
 matplotlib==3.1.0
-snakemake-minimal==5.7.1
 
 # to check python code style
 pycodestyle


### PR DESCRIPTION
Instead of manual workaround, adding snakemake first works on linux. Latest supported version of snakemake is 3.13.3.