### PR TITLE
Un-bashing of the Snakefile

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -20,7 +20,6 @@ rule count_words:
     log: 'processed_data/{file}.log'
     shell:
         '''
-        echo "Running {input.wc} with {threads} cores on {input.book}." &> {log} &&
             python {input.wc} {input.book} {output} >> {log} 2>&1
         '''
 


### PR DESCRIPTION
Now works on Windows Cmd prompt and on Windows with Anaconda prompt.
Closes coderefinery/reproducible-research#130
Closes coderefinery/reproducible-research#124