### PR TITLE
Add end-to-end tests

### DIFF
--- a/tests/end-to-end-python.py
+++ b/tests/end-to-end-python.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+
+# This should be run from the main word-count directory, *not* the `tests/`
+# directory.
+
+import subprocess
+import sys
+
+# Run count.py using whatever Python we are using right now.  Get the output as
+# a string.
+output = subprocess.check_output([sys.executable, 'statistics/count.py', 'data/abyss.txt']).decode()
+
+# Split the string and confirm the expected lines are in there.
+output = output.split('\n')
+assert 'the 4044' in output
+assert 'and 2807' in output
+print("Success")

--- a/tests/end-to-end-shell.sh
+++ b/tests/end-to-end-shell.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# This should be run from the main word-count directory, *not* the `tests/`
+# directory.
+
+# This is an end-to-end test of count.py.  It runs the script and
+# tests that a few lines are correct.
+
+# Check that `the` appears 4044 times.  The 'grep' command returns
+# true if somethin is found that matches.
+if python3 statistics/count.py data/abyss.txt | grep "the 4044" ; then
+    echo "Success: 'the' found correct number of times"
+else
+    echo "Fail: 'the' not correct"
+    exit 1
+fi
+
+
+# Check that `and` appears 2807 times
+if python3 statistics/count.py data/abyss.txt | grep "and 2807" ; then
+    echo "Success: 'and' found correct number of times"
+else
+    echo "Fail: 'and' not correct"
+    exit 1
+fi
+
+echo "Success"


### PR DESCRIPTION
- Add a Python and Shell example for end to end tests.  This is
  because hopefully at least one works...

- Review: are the forms of these good?  I probably wouldn't do either
  of these myself, I'd make something more robust.  However, these are
  supposed to be simple enough that it will work on anyone's computer
  and be easy to understand.  Unfortunately that's not the 'best' way
  of doing it.
