### PR TITLE
Bump snakemake-minimal version to 8.5.3

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,4 +6,5 @@ dependencies:
   - python>3.9
   - click=8.1.3
   - matplotlib=3.7.0
-  - snakemake-minimal=7.22.0
+  - snakemake-minimal=8.5.3
+  - graphviz=9.0.0

--- a/environment.yml
+++ b/environment.yml
@@ -7,4 +7,3 @@ dependencies:
   - click=8.1.3
   - matplotlib=3.7.0
   - snakemake-minimal=8.5.3
-  - graphviz=9.0.0

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,8 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - python>3.9
-  - click=8.1.3
-  - matplotlib=3.7.0
+  - python>=3.10
+  - click=8.1.7
+  - matplotlib=3.8.3
   - snakemake-minimal=8.5.3
+  - pulp<2.8.0


### PR DESCRIPTION
The snakemake-minimal version 7.22 is a bit outdated, the latest is 8.5.3. However, the basic functionality of Snakemake used in the exercise hasn't changed so 7.22 is also fine.

Tested the exercises and running them with version 8.5.3 did not require any other changes.


